### PR TITLE
More space for title bar and button texts

### DIFF
--- a/TGUIKit/TGUIKit/BarView.swift
+++ b/TGUIKit/TGUIKit/BarView.swift
@@ -13,7 +13,7 @@ open class BarView: OverlayControl {
     
     public var clickHandler:()->Void = {}
     
-    public var minWidth:CGFloat = 80
+    public var minWidth:CGFloat = 95
     public private(set) weak var controller: ViewController?
     
     
@@ -27,7 +27,7 @@ open class BarView: OverlayControl {
         self.setNeedsDisplay()
     }
     
-    public init(_ width:CGFloat = 80, controller: ViewController) {
+    public init(_ width:CGFloat = 95, controller: ViewController) {
         self.minWidth = width
         self.controller = controller
         super.init()

--- a/TGUIKit/TGUIKit/TitledBarView.swift
+++ b/TGUIKit/TGUIKit/TitledBarView.swift
@@ -18,7 +18,7 @@ private class TitledContainerView : View {
         }
     }
     
-    var inset:CGFloat = 50
+    var inset:CGFloat = 0
     
     var text:NSAttributedString? {
         didSet {
@@ -129,7 +129,7 @@ open class TitledBarView: BarView {
     }
     
     open var inset:CGFloat {
-        return 50
+        return 0
     }
 
     public var textInset:CGFloat? {


### PR DESCRIPTION
## Example:

### Before:
![image](https://user-images.githubusercontent.com/4332273/31520412-0eb03b6c-afa6-11e7-80b6-8a220b2b0c8b.png)

### After:
![image](https://user-images.githubusercontent.com/4332273/31520222-746493a0-afa5-11e7-8006-9d470a98091e.png)

I couldn't find a place where TitledBarView with inset 50 is needed in the app, so I set it to 0.
Does that break anything?