### PR TITLE
If reply keyboard is not all visible, display visual hint that there is more rows

### DIFF
--- a/Telegram-Mac/ChatInputView.swift
+++ b/Telegram-Mac/ChatInputView.swift
@@ -66,6 +66,9 @@ class ChatInputView: Control, TGModernGrowingDelegate, Notifable {
     
     private var standart:CGFloat = 50.0
     private var bottomHeight:CGFloat = 0
+
+    static let bottomPadding:CGFloat = 10
+    static let maxBottomHeight = ReplyMarkupNode.rowHeight * 3 + ReplyMarkupNode.buttonHeight / 2
     
     init(frame frameRect: NSRect, chatInteraction:ChatInteraction) {
         self.chatInteraction = chatInteraction
@@ -426,7 +429,10 @@ class ChatInputView: Control, TGModernGrowingDelegate, Notifable {
         let contentHeight:CGFloat = defaultContentHeight + yInset * 2.0
         var sumHeight:CGFloat = contentHeight + (accessory.isVisibility() ? accessory.size.height + 5 : 0)
         if let markup = replyMarkupModel  {
-            bottomHeight = min(110,markup.size.height) + 10
+            bottomHeight = min(
+              ChatInputView.maxBottomHeight,
+              markup.size.height + ChatInputView.bottomPadding
+            )
         } else {
             bottomHeight = 0
         }

--- a/Telegram-Mac/ReplyMarkupNode.swift
+++ b/Telegram-Mac/ReplyMarkupNode.swift
@@ -34,6 +34,10 @@ class ReplyMarkupButtonLayout {
 }
 
 class ReplyMarkupNode: Node {
+
+    static let buttonHeight:CGFloat = 34
+    static let buttonPadding:CGFloat = 6
+    static let rowHeight = buttonHeight + buttonPadding
     
     private var width:CGFloat = 0
     private var height:CGFloat = 0
@@ -117,7 +121,7 @@ class ReplyMarkupNode: Node {
                 if j == row.count - 1 {
                     w = self.width - rect.minX
                 }
-                rect.size = NSMakeSize(w, 34)
+                rect.size = NSMakeSize(w, ReplyMarkupNode.buttonHeight)
                 let button:View? = view?.subviews[i] as? View
                 button?.backgroundColor = theme.colors.grayBackground
                 if let button = button {
@@ -128,11 +132,11 @@ class ReplyMarkupNode: Node {
                     }
                 }
                 
-                rect = rect.offsetBy(dx: w + 6, dy: 0)
+                rect = rect.offsetBy(dx: w + ReplyMarkupNode.buttonPadding, dy: 0)
                 i += 1
                 j += 1
             }
-            y += 40
+            y += ReplyMarkupNode.rowHeight
         }
     }
     


### PR DESCRIPTION
I'm writing a bot that occasionally provides more than three rows of keyboard buttons. This version of Telegram does not provide any indication that not all buttons are visible:

<img alt="screen shot 2017-10-24 at 15 05 24 pm" src="https://user-images.githubusercontent.com/116518/31942113-e558031e-b8cc-11e7-8ae5-950fc53c1565.png">

I've extended the max height of the bottom view so it will show a part of the fourth row:

![screen shot 2017-10-24 at 15 05 57 pm](https://user-images.githubusercontent.com/116518/31942115-e84551f8-b8cc-11e7-9240-aea411d28ea2.png)

It's a subtle but effective indication that there is some content to scroll to.

(Telegram for iOS does something similar already.)

---

I also extracted the "magic" numbers in these calculations into constants, so the logic is clearer.