### PR TITLE
Fix path to sandboxed ~/Library/Sounds directory

### DIFF
--- a/Telegram-Mac/ObjcUtils.m
+++ b/Telegram-Mac/ObjcUtils.m
@@ -693,7 +693,8 @@ double mappingRange(double x, double in_min, double in_max, double out_min, doub
     
     [list addObject:@"NotificationSettingsToneNone"];
     
-    NSArray *dirContents = [fm contentsOfDirectoryAtPath:@"~/Library/Sounds" error:nil];
+    NSString *homeSoundsPath = [NSHomeDirectory() stringByAppendingString:@"/Library/Sounds"];
+    NSArray *dirContents = [fm contentsOfDirectoryAtPath:homeSoundsPath error:nil];
     [list addObjectsFromArray:[dirContents filteredArrayUsingPredicate:fltr]];
     
     dirContents = [fm contentsOfDirectoryAtPath:@"/Library/Sounds" error:nil];


### PR DESCRIPTION
The path previously used, `~/Library/Sounds`, is neither expanded into a full path by `NSString`'s `stringByExpandingTildeInPath:`, nor is it available from within the sandbox in the first place. This patch proposes to use `NSHomeDirectory()` to obtain the path to the home directory in the app container.

Here is a simple test:

    cp /Applications/Messages.app/Contents/Resources/Default.aiff ~/Library/Sounds/Incoming.aiff
    # Start Telegram, go to Settings > Notifications > Notification Tone and choose "Incoming"
    # Finally, clean up:
    rm ~/Library/Sounds/Incoming.aiff