### PR TITLE
Fix broken brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ### Using Homebrew
 
 ```
-brew cask install telegram
+brew install --cask telegram
 ```
 
 ### Using `mas-cli`


### PR DESCRIPTION
The current install command runs into following error:
>Error: Calling brew cask install is disabled! Use brew install [--cask] instead.

This PR fixes the broken install command.