### PR TITLE
update brew installation command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ### Using Homebrew
 
 ```
-brew cask install telegram
+brew install telegram
 ```
 
 ### Using `mas-cli`


### PR DESCRIPTION
`brew cask` [was deprecated since 2020-12-01 and already got completely removed from brew as of brew 2.8.0](https://github.com/ansible-collections/community.general/issues/1524#issuecomment-749945392). Users should now use `brew install` instead of `brew cask install`