### PR TITLE
Remove unused variable minute_duration

### DIFF
--- a/Telegram-Mac/SendingClockProgress.swift
+++ b/Telegram-Mac/SendingClockProgress.swift
@@ -9,10 +9,6 @@
 import Cocoa
 import TGUIKit
 
-
-
-fileprivate let minute_duration:Double = 1.2
-
 class SendingClockProgress: View {
     
     private var isAnimating:Bool = false


### PR DESCRIPTION
The variable file-private variable `minute_duration` is not used anywhere in any way so I removed it.