### PR TITLE
fix Telegram icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="Telegram-Mac/Assets.xcassets/AppIcon.appiconset/Default_128x128.png">
+  <img src="Telegram-Mac/Assets.xcassets/AppIcon.appiconset/Logo_128.png">
   <h2 align="center">Telegram for macOS</h2>
 </div>
 


### PR DESCRIPTION
old: https://github.com/overtake/TelegramSwift/blob/master/Telegram-Mac/Assets.xcassets/AppIcon.appiconset/Default_128x128.png

new: https://raw.githubusercontent.com/overtake/TelegramSwift/master/Telegram-Mac/Assets.xcassets/AppIcon.appiconset/Logo_128.png