### PR TITLE
Correct submodule urls

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@ url=git@github.com:overtake/Telegram-iOS.git
 url=git@github.com:overtake/rlottie.git
 [submodule "submodules/tgcalls"]
 	path = submodules/tgcalls
-	url = git@github.com:john-preston/tgcalls.git
+	url = git@github.com:TelegramMessenger/tgcalls.git
 [submodule "submodules/tg_owt"]
 	path = submodules/tg_owt
 	url = git@github.com:desktop-app/tg_owt.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@ url=git@github.com:telegramdesktop/libtgvoip
 url=git@gitlab.com:overtake/Sparkle.git
 [submodule "submodules/telegram-ios"]
 	path = submodules/telegram-ios
-url=git@github.com:overtake/Telegram-iOS.git
+url=git@github.com:TelegramMessenger/Telegram-iOS.git
 [submodule "submodules/rlottie"]
 	path = submodules/rlottie
 url=git@github.com:overtake/rlottie.git


### PR DESCRIPTION
This is to correct submodule urls since overtake/Telegram-iOS and john-preston/tgcalls are moved to TelegramMessenger/*