### PR TITLE
update readme about Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ### Using Homebrew
 
 ```
-brew cask install telegram
+brew install --cask telegram
 ```
 
 ### Using `mas-cli`


### PR DESCRIPTION
to fix error:
Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.