### PR TITLE
Fix deadlock in MediaPlayer.

### DIFF
--- a/Telegram-Mac/MediaPlayerAudioRenderer.swift
+++ b/Telegram-Mac/MediaPlayerAudioRenderer.swift
@@ -693,6 +693,13 @@ final class MediaPlayerAudioRenderer {
     let audioTimebase: CMTimebase
     
     init(playAndRecord: Bool, forceAudioToSpeaker: Bool, baseRate: Double, volume: Float, updatedRate: @escaping () -> Void, audioPaused: @escaping () -> Void) {
+        
+        // Here we are probably running inside of playerQueue.
+        // For some reason deadlock may occure in case of intensive MediaPlayerAudioRenderer object creation.
+        // Let's wait until `audioPlayerRendererQueue` finish all scheduled jobs,
+        // including "garabage" collection of previous object.
+        audioPlayerRendererQueue.sync{}
+
         var audioClock: CMClock?
         
         var deviceId:AudioDeviceID = AudioDeviceID()


### PR DESCRIPTION
There is an issue with MediaPlayer.

We have at least 3 bug reports that covers that:
https://bugs.telegram.org/c/20486
https://bugs.telegram.org/c/21311
https://github.com/overtake/TelegramSwift/issues/892

Personally I like description of [this one](https://bugs.telegram.org/c/21311).

But in general when the video ends or when you rewind it, there is a chance that all videos stops to play (until you restart the app) or the main thread deadlocks (app just hangs) and you need to restart the application.

It's easy to reproduce on Macbook with 2,4 GHz 8-Core Intel Core i9. But I couldn't reproduce it on Macbook Air with 2 slow cores.


The reason of that behaviour is deadlock that occurs when using some CoreMedia components (from my observation CM clock or time related functions, like `CMAudioDeviceClockCreate`).

I made an assumption that this can occur because of the race condition when we create MediaPlayerAudioRenderer. So we creating it from `playerQueue` queue and there is a chance that in `audioPlayerRendererQueue` there are still tasks related to cleaning up of the previous object. So we need to wait until all cleaning happens and then create required objects.

With suggested changes I couldn't reproduce the issue.

Let me know if you need more details, I can provide threads stacktrace with deadlock, or video to reproduce this bug.





