### PR TITLE
Fix brew command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ### Using Homebrew
 
 ```
-brew cask install telegram
+brew install --cask telegram
 ```
 
 ### Using `mas-cli`


### PR DESCRIPTION
`brew cask` is no longer a `brew` command
https://github.com/Homebrew/discussions/discussions/902#discussioncomment-398348