### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ### Using Homebrew
 
 ```
-brew cask install telegram
+brew install cask telegram
 ```
 
 ### Using `mas-cli`


### PR DESCRIPTION
Brew now works the other way around with cask

```
 ~/ brew cask install telegram
Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.
 ~/ brew install cask telegram
==> Auto-updating Homebrew...
```