### PR TITLE
Revert currentKeyboardLanguage change in emoji selector

### DIFF
--- a/Telegram-Mac/InputSources.swift
+++ b/Telegram-Mac/InputSources.swift
@@ -19,7 +19,7 @@ final class InputSources: NSObject {
     
     var value: Signal<[String], NoError> {
         _inputSource.set(Signal { subscriber in
-            subscriber.putNext([currentKeyboardLanguage()])
+            subscriber.putNext(currentAppInputSource().uniqueElements)
             subscriber.putCompletion()
             return EmptyDisposable
         } |> runOn(.mainQueue()))


### PR DESCRIPTION
ℹ️ This was originally opened as https://github.com/overtake/TelegramSwift/pull/1252, but closed accidentally while sync'ing branches.

Reverts a change to `InputSources.swift` introduced in 4fabc33116d33f60d92eab1327b05ee73237f48d that made emoji search depend on the current keyboard layout (e.g., Spanish), rather than the system language (e.g., English).

This restores the previous behavior by using `currentAppInputSource().uniqueElements` instead of `currentKeyboardLanguage()`, ensuring emoji search results align with the system language preferences.

This should fix https://github.com/overtake/TelegramSwift/issues/1200