### PR TITLE
Fix text substitution property setters

### DIFF
--- a/packages/InputView/Sources/InputView/ChatInputTextView.swift
+++ b/packages/InputView/Sources/InputView/ChatInputTextView.swift
@@ -1325,7 +1325,7 @@ public final class InputTextView: NSTextView, NSLayoutManagerDelegate, NSTextSto
         }
         set {
             UserDefaults.standard.set(newValue, forKey: "AutomaticQuoteSubstitutionEnabled\(settingsKey)")
-            super.isAutomaticSpellingCorrectionEnabled = newValue
+            super.isAutomaticQuoteSubstitutionEnabled = newValue
         }
     }
 
@@ -1335,7 +1335,7 @@ public final class InputTextView: NSTextView, NSLayoutManagerDelegate, NSTextSto
         }
         set {
             UserDefaults.standard.set(newValue, forKey: "AutomaticLinkDetectionEnabled\(settingsKey)")
-            super.isAutomaticSpellingCorrectionEnabled = newValue
+            super.isAutomaticLinkDetectionEnabled = newValue
         }
     }
 
@@ -1345,7 +1345,7 @@ public final class InputTextView: NSTextView, NSLayoutManagerDelegate, NSTextSto
         }
         set {
             UserDefaults.standard.set(newValue, forKey: "AutomaticDataDetectionEnabled\(settingsKey)")
-            super.isAutomaticSpellingCorrectionEnabled = newValue
+            super.isAutomaticDataDetectionEnabled = newValue
         }
     }
 
@@ -1355,7 +1355,7 @@ public final class InputTextView: NSTextView, NSLayoutManagerDelegate, NSTextSto
         }
         set {
             UserDefaults.standard.set(newValue, forKey: "AutomaticDashSubstitutionEnabled\(settingsKey)")
-            super.isAutomaticSpellingCorrectionEnabled = newValue
+            super.isAutomaticDashSubstitutionEnabled = newValue
         }
     }
 }


### PR DESCRIPTION
## Summary

Fix copy-paste bug in `ChatInputTextView` property setters.

Setters for `isAutomaticQuoteSubstitutionEnabled`, `isAutomaticLinkDetectionEnabled`, `isAutomaticDataDetectionEnabled`, and `isAutomaticDashSubstitutionEnabled` were all incorrectly calling `super.isAutomaticSpellingCorrectionEnabled` instead of their corresponding `super` property.

This causes data detectors (and other text substitution settings) to not actually be toggled on the underlying `NSTextView`, while instead silently toggling spelling correction. For example, toggling "Data Detectors" in the Edit menu has no visible effect on detection of phrases like "in 5 minutes", because the actual `isAutomaticDataDetectionEnabled` on `NSTextView` is never set.