### PR TITLE
Fix underscore slash command autocomplete

### DIFF
--- a/Telegram-Mac/ChatInterfaceInputContext.swift
+++ b/Telegram-Mac/ChatInterfaceInputContext.swift
@@ -10,6 +10,7 @@ import Cocoa
 import TelegramCore
 
 import Postbox
+import FoundationUtils
 
 struct PossibleContextQueryTypes: OptionSet {
     var rawValue: Int32
@@ -90,6 +91,9 @@ func textInputStateContextQueryRangeAndType(_ inputState: ChatTextInputState, in
         }
         if maxIndex == inputText.startIndex {
             return nil
+        }
+        if let commandQueryRange = TelegramCommandAutocomplete.queryRange(in: inputText, cursorUTF16Offset: inputState.selectionRange.lowerBound) {
+            return (commandQueryRange, [.command], nil)
         }
         var index = inputText.index(before: maxIndex)
         

--- a/packages/FoundationUtils/Package.swift
+++ b/packages/FoundationUtils/Package.swift
@@ -21,5 +21,8 @@ let package = Package(
         .target(
             name: "FoundationUtils",
             dependencies: []),
+        .testTarget(
+            name: "FoundationUtilsTests",
+            dependencies: ["FoundationUtils"]),
     ]
 )

--- a/packages/FoundationUtils/Sources/FoundationUtils/TelegramCommandAutocomplete.swift
+++ b/packages/FoundationUtils/Sources/FoundationUtils/TelegramCommandAutocomplete.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public enum TelegramCommandAutocomplete {
+    public static func queryRange(in text: String, cursorUTF16Offset: Int) -> Range<String.Index>? {
+        let cursorUTF16Offset = min(max(0, cursorUTF16Offset), text.utf16.count)
+        let cursorUTF16Index = text.utf16.index(text.utf16.startIndex, offsetBy: cursorUTF16Offset)
+        guard let cursorIndex = cursorUTF16Index.samePosition(in: text) else {
+            return nil
+        }
+        guard text.startIndex < cursorIndex, text.first == "/" else {
+            return nil
+        }
+        if cursorIndex < text.endIndex, !text[cursorIndex].isWhitespace {
+            return nil
+        }
+        let commandStartIndex = text.index(after: text.startIndex)
+        for character in text[commandStartIndex ..< cursorIndex] {
+            guard isValidCommandCharacter(character) else {
+                return nil
+            }
+        }
+        return commandStartIndex ..< cursorIndex
+    }
+    
+    private static func isValidCommandCharacter(_ character: Character) -> Bool {
+        if character == "_" {
+            return true
+        }
+        guard let scalar = character.unicodeScalars.first, character.unicodeScalars.count == 1 else {
+            return false
+        }
+        return CharacterSet.alphanumerics.contains(scalar)
+    }
+}

--- a/packages/FoundationUtils/Tests/FoundationUtilsTests/TelegramCommandAutocompleteTests.swift
+++ b/packages/FoundationUtils/Tests/FoundationUtilsTests/TelegramCommandAutocompleteTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import FoundationUtils
+
+final class TelegramCommandAutocompleteTests: XCTestCase {
+    func testKeepsAutocompleteOpenForAlphanumericCommandQuery() {
+        let text = "/codex"
+        
+        let range = TelegramCommandAutocomplete.queryRange(in: text, cursorUTF16Offset: text.utf16.count)
+        
+        XCTAssertNotNil(range)
+        XCTAssertEqual(String(text[range!]), "codex")
+    }
+    
+    func testKeepsAutocompleteOpenForUnderscoreInCommandQuery() {
+        let text = "/codex_compact"
+        
+        let range = TelegramCommandAutocomplete.queryRange(in: text, cursorUTF16Offset: text.utf16.count)
+        
+        XCTAssertNotNil(range)
+        XCTAssertEqual(String(text[range!]), "codex_compact")
+    }
+    
+    func testRejectsInvalidCommandCharacters() {
+        let text = "/codex-compact"
+        
+        let range = TelegramCommandAutocomplete.queryRange(in: text, cursorUTF16Offset: text.utf16.count)
+        
+        XCTAssertNil(range)
+    }
+}


### PR DESCRIPTION
## Summary
- allow `_` while parsing slash-command autocomplete queries
- add regression tests for command autocomplete parsing in `FoundationUtils`
- keep autocomplete open for commands like `/foo_bar`

## Testing
- `swift test` in `packages/FoundationUtils`
- manual verification in the macOS app: typing `_` in a slash command no longer closes autocomplete

## Screenshots
| Before | After |
| --- | --- |
| <img width="929" height="860" alt="image" src="https://github.com/user-attachments/assets/9bf70ac0-0f16-4d15-b274-01bea0958268" /> | <img width="1096" height="831" alt="image" src="https://github.com/user-attachments/assets/4bcfb171-1835-4e94-9991-df663711e406" /> |

Fixes #1350
