### PR TITLE
Fix cursor hidden and audio leak after closing media viewer

### DIFF
--- a/Telegram-Mac/AppDelegate.swift
+++ b/Telegram-Mac/AppDelegate.swift
@@ -1495,8 +1495,12 @@ class AppDelegate: NSResponder, NSApplicationDelegate, NSUserNotificationCenterD
     
     func applicationDidResignActive(_ notification: Notification) {
         updatePeerPresence()
-        if viewer != nil, NSScreen.main == viewer?.window.screen {
-            viewer?.window.orderOut(nil)
+        if let viewer = viewer {
+            if let appScreen = self.window.screen, let viewerScreen = viewer.window.screen, appScreen != viewerScreen {
+                viewer.close(false)
+            } else {
+                viewer.window.orderOut(nil)
+            }
         }
         self.activeValue.set(false)
     }

--- a/Telegram-Mac/GalleryViewer.swift
+++ b/Telegram-Mac/GalleryViewer.swift
@@ -262,7 +262,8 @@ class GalleryViewer: NSResponder {
         self.chatLocation = chatLocation
         self.reversed = reversed
         self.contentInteractions = contentInteractions
-        if let screen = NSScreen.main {
+        let galleryScreen = context.window.screen ?? NSScreen.main
+        if let screen = galleryScreen {
             let bounds = NSMakeRect(0, 0, screen.frame.width, screen.frame.height)
             self.window = Window(contentRect: bounds, styleMask: [.borderless], backing: .buffered, defer: false, screen: screen)
             self.window.contentView?.wantsLayer = true
@@ -295,6 +296,7 @@ class GalleryViewer: NSResponder {
         
         NotificationCenter.default.addObserver(self, selector: #selector(windowDidBecomeKey), name: NSWindow.didBecomeKeyNotification, object: window)
         NotificationCenter.default.addObserver(self, selector: #selector(windowDidResignKey), name: NSWindow.didResignKeyNotification, object: window)
+        NotificationCenter.default.addObserver(self, selector: #selector(screenParametersDidChange), name: NSApplication.didChangeScreenParametersNotification, object: nil)
         
         
         interactions.dismiss = { [weak self] _ -> KeyHandlerResult in
@@ -470,8 +472,19 @@ class GalleryViewer: NSResponder {
     
     
     @objc open func windowDidResignKey() {
-        self.window.makeKeyAndOrderFront(self)
-      //  window.makeFirstResponder(self)
+      // Keep system focus behavior intact to avoid stuck key-window state across displays.
+    }
+
+    @objc private func screenParametersDidChange() {
+        guard self.window.isVisible else {
+            return
+        }
+        guard let appScreen = self.context.window.screen, let viewerScreen = self.window.screen else {
+            return
+        }
+        if appScreen != viewerScreen {
+            self.close(false)
+        }
     }
     
     var pagerSize: NSSize {

--- a/Telegram-Mac/GalleryViewer.swift
+++ b/Telegram-Mac/GalleryViewer.swift
@@ -1680,6 +1680,7 @@ class GalleryViewer: NSResponder {
                 
             })
         } else {
+            pager.selectedItem?.disappear(for: nil)
             window.orderOut(nil)
             viewer = nil
             playPipIfNeeded()

--- a/Telegram-Mac/SVideoController.swift
+++ b/Telegram-Mac/SVideoController.swift
@@ -58,6 +58,7 @@ class SVideoController: GenericViewController<SVideoView>, PictureInPictureContr
     
     private var isPaused: Bool = true
     private var forceHiddenControls: Bool = false
+    private var isCursorHidden: Bool = false
     private var _videoFramePreview: MediaPlayerFramePreview?
     private var mode: PictureInPictureControlMode = .normal
     
@@ -162,13 +163,17 @@ class SVideoController: GenericViewController<SVideoView>, PictureInPictureContr
     
     
     private func updateIdleTimer() {
-        NSCursor.unhide()
+        if isCursorHidden {
+            NSCursor.unhide()
+            isCursorHidden = false
+        }
         hideOnIdleDisposable.set((Signal<NoValue, NoError>.complete() |> delay(1.0, queue: Queue.mainQueue())).start(completed: { [weak self] in
             guard let `self` = self else {return}
             let hide = !self.genericView.isInMenu && !self.genericView.insideControls && !contextMenuOnScreen()
             self.hideControls.set(hide)
-            if !self.pictureInPicture, hide {
+            if !self.pictureInPicture, hide, !self.isCursorHidden {
                 NSCursor.hide()
+                self.isCursorHidden = true
             }
         }))
     }
@@ -187,9 +192,10 @@ class SVideoController: GenericViewController<SVideoView>, PictureInPictureContr
             
             if self.fullScreenWindow != nil && isMouseUpOrDown, !genericView.insideControls {
                 hide = true
-                if !self.isPaused {
+                if !self.isPaused, !self.isCursorHidden {
                     if !contextMenuOnScreen() {
                         NSCursor.hide()
+                        self.isCursorHidden = true
                     }
                 }
             }
@@ -334,7 +340,10 @@ class SVideoController: GenericViewController<SVideoView>, PictureInPictureContr
         super.viewWillDisappear(animated)
         hideOnIdleDisposable.set(nil)
         _ = enableScreenSleep()
-        NSCursor.unhide()
+        if isCursorHidden {
+            NSCursor.unhide()
+            isCursorHidden = false
+        }
         window?.removeAllHandlers(for: self)
         
     }

--- a/packages/TelegramMedia/Sources/MediaPlayer.swift
+++ b/packages/TelegramMedia/Sources/MediaPlayer.swift
@@ -376,7 +376,15 @@ private final class MediaPlayerContext {
                     if let strongSelf = self {
                         
                         if let loadedState = loadedState {
-                            switch action {
+                            // Re-read the current action from state so that a pause() call made
+                            // between seekingCompleted() and the flush completing is respected.
+                            let currentAction: MediaPlayerPlaybackAction
+                            if case let .seeking(_, _, _, stateAction, _) = strongSelf.state {
+                                currentAction = stateAction
+                            } else {
+                                currentAction = action
+                            }
+                            switch currentAction {
                             case .play:
                                 strongSelf.state = .playing(loadedState)
                                 strongSelf.audioRenderer?.renderer.start()


### PR DESCRIPTION
Fixes #1303

Also fixes #269

## Changes

### Bug 1 - Cursor stays hidden system-wide after media viewer closes

Root cause: macOS cursor visibility uses a reference-counted system - NSCursor.hide() and NSCursor.unhide() must be balanced. Two separate code paths in SVideoController called NSCursor.hide():

1. updateIdleTimer() - hides the cursor after 1 second of mouse idle
2. updateControlVisibility(true) (fullscreen mouseDown/mouseUp path) - also calls NSCursor.hide() independently

But viewDidDisappear() only called NSCursor.unhide() once, leaving the reference count unbalanced when both paths had fired. Additionally, GalleryViewer.close(animated: false) ordered the window out without ever calling item.disappear(), so viewDidDisappear() (and its NSCursor.unhide()) never ran at all on non-animated closes (for example pressing Escape).

Fixes (SVideoController.swift, GalleryViewer.swift):
- SVideoController: Introduced isCursorHidden: Bool to track cursor state. Every NSCursor.hide() is guarded by !isCursorHidden and every NSCursor.unhide() is guarded by isCursorHidden, guaranteeing exactly one matched pair per lifecycle regardless of which code paths fire.
- GalleryViewer.close(animated:): Call pager.selectedItem?.disappear(for: nil) before window.orderOut(nil) in the non-animated path, ensuring viewDidDisappear always runs on close.

### Bug 2 - Audio continues playing after navigating away or closing the viewer

Root cause: In MediaPlayerContext.seekingCompleted(), the current playback action (for example .play) is read from self.state and captured into the audioRenderer.flushBuffers(completion:) closure. While the flush is in flight, if pause() is called (for example the user navigates to the next item or closes the viewer), self.state's action is updated to .pause - but the completion closure uses the stale captured .play, sets state to .playing, and starts the audio renderer anyway.

This is particularly noticeable with large remote videos on slow connections, where buffering causes a long flush that outlasts viewer dismissal.

Fix (packages/TelegramMedia/Sources/MediaPlayer.swift):
- In the flushBuffers completion closure, re-read the current action from self.state (when still in .seeking) rather than using the value captured at seek time, so any pause() call made during the flush is correctly honoured.

### Bug 3 - Full-screen media viewer behaves incorrectly across multiple monitors

Root cause: GalleryViewer always created its full-screen window on NSScreen.main and forcibly reclaimed key-window status on resign. When the app focus moved to another display, the viewer could close unexpectedly or leave Telegram in a bad state that required relaunch.

Fixes (GalleryViewer.swift, AppDelegate.swift):
- Open the gallery window on the app window's current screen instead of hardcoding NSScreen.main.
- Stop forcibly re-focusing the gallery window on resign-key.
- When app and viewer screens diverge, close the viewer cleanly instead of leaving stale viewer state behind.