### PR TITLE
Fix black screen when per-chat wallpaper fails to download

### DIFF
--- a/Telegram-Mac/ChatController.swift
+++ b/Telegram-Mac/ChatController.swift
@@ -3268,7 +3268,7 @@ class ChatController: EditableViewController<ChatControllerView>, Notifable, Tab
                         }
                     }
                 case .loading:
-                    break
+                    current.presentation = theme.withUpdatedEmoticonThemes(emoticonThemes)
                 }
                 return current
             }


### PR DESCRIPTION
## Summary

- When a channel has a custom wallpaper that isn't cached locally, `themeWallpaper` emits `.loading` followed by `moveWallpaperToCache`. If the wallpaper resource never fully downloads, `moveWallpaperToCache` returns `.complete()` without emitting a value (`CoreExtension.swift:2845`), so `.result(...)` is never delivered.
- The `.loading` case in the presentation update handler (`ChatController.swift:3270`) was a no-op (`break`), meaning the presentation theme was never applied.
- Since the `TableView` background is `.clear` and no `BackgroundView` overlay was created without a theme, the chat rendered as a completely black/blank screen.

## Fix

Apply the base theme with emoticon themes during `.loading` (same call as the `.result` path at line 3257), so there is always a visible background while the wallpaper is being fetched. Once the wallpaper finishes downloading, the `.result` case fires and applies the wallpaper on top — no change in behavior for the happy path.

## Reproduction

1. Open a channel that has a custom wallpaper set by admin
2. The wallpaper file fails to download or takes too long
3. Message area renders completely black — no messages visible
4. Web client and iOS work fine for the same channel

Fixes #1369