### PR TITLE
Fix build compatibility with Xcode 26 / modern toolchains

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,7 +10,7 @@
 	```
 3. Install tools: 
 	```
-	brew install cmake ninja openssl@1.1 zlib autoconf libtool automake yasm pkg-config
+	brew install cmake ninja openssl@1.1 zlib autoconf libtool automake yasm nasm meson pkg-config
  	```
 4. Update ./scripts/rebuild file 
 	```

--- a/core-xprojects/Mozjpeg/Mozjpeg/build.sh
+++ b/core-xprojects/Mozjpeg/Mozjpeg/build.sh
@@ -35,7 +35,7 @@ echo "set(CMAKE_SYSTEM_PROCESSOR AMD64)" >> toolchain.cmake
 fi
 echo "set(CMAKE_C_COMPILER $(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang)" >> toolchain.cmake
 
-cmake -G"Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE=toolchain.cmake -DCMAKE_OSX_SYSROOT=${MACOS_SYSROOT[0]} -DPNG_SUPPORTED=FALSE -DENABLE_SHARED=FALSE -DWITH_JPEG8=1 ../../$SOURCE_DIR
+cmake -G"Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE=toolchain.cmake -DCMAKE_OSX_SYSROOT=${MACOS_SYSROOT[0]} -DPNG_SUPPORTED=FALSE -DENABLE_SHARED=FALSE -DWITH_JPEG8=1 -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ../../$SOURCE_DIR
 make
 
 cd ..

--- a/core-xprojects/ffmpeg/ffmpeg/build.sh
+++ b/core-xprojects/ffmpeg/ffmpeg/build.sh
@@ -29,7 +29,7 @@ LIBOPUS_PATH="${BUILD_DIR}../../libopus/build/libopus"
 LIBVPX_PATH="${BUILD_DIR}../../libvpx/build/libvpx"
 LIBDAV1D_PATH="${BUILD_DIR}../../dav1d/build/dav1d"
 
-FF_VERSION="7.1"
+FF_VERSION="7.1.1"
 SOURCE="$SOURCE_DIR/ffmpeg-$FF_VERSION"
 
 GAS_PREPROCESSOR_PATH="$SOURCE_DIR/gas-preprocessor.pl"


### PR DESCRIPTION
## Summary
- Add missing Homebrew dependencies (`nasm`, `meson`) to INSTALL.md
- Fix CMake policy deprecation error in Mozjpeg build script
- Fix ffmpeg version mismatch in build script (`7.1` → `7.1.1`)
- Document additional submodule-level issues and Metal Toolchain workaround for Xcode 26

## Context

Building TelegramSwift from source on **Xcode 26** (macOS 26 / Tahoe) with **CMake 3.31** surfaces several issues, ranging from missing documented dependencies to CMake policy errors, ffmpeg version mismatches, and clang compatibility breaks. This PR addresses the issues fixable within the main repository and documents workarounds for environment-level issues.

### All issues discovered during the Xcode 26 build:

1. **Missing brew dependencies** — `meson` (required by the dav1d build script) and `nasm` (required by the OpenH264 build script) are not listed in INSTALL.md, causing `configure_frameworks.sh` to fail for first-time builders.
2. **CMake policy deprecation error** — CMake 3.27+ enforces `CMP0000` strictly when `cmake_minimum_required` is set to a very old version. The Mozjpeg build fails with: `CMake Error at CMakeLists.txt — Policy "CMP0000" is not known to this version of CMake`. Adding `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` resolves this.
3. **ffmpeg version mismatch** — The ffmpeg build script (`core-xprojects/ffmpeg/ffmpeg/build.sh`) sets `FF_VERSION="7.1"` but the bundled source in `telegram-ios` submodule is at `ffmpeg-7.1.1`, causing the build to fail with "FFmpeg source not found".
4. **Metal Toolchain `libswiftAppKit.dylib` missing** — Xcode 26's Metal Toolchain is mounted as a read-only cryptex at `/var/run/com.apple.security.cryptexd/mnt/com.apple.MobileAsset.MetalToolchain-*/Metal.xctoolchain/` but does NOT contain `usr/lib/swift-5.0/macosx/libswiftAppKit.dylib`. The linker is passed this path directly and fails. See **Workaround** below.
5. **`ABSL_ATTRIBUTE_LIFETIME_BOUND` clang error** (submodule: `tg_owt`) — Xcode 26's clang rejects `[[clang::lifetimebound]]` on parameters of void-returning functions. Affects `submodules/tg_owt/src/api/candidate.h` line 108 in `set_type()`.

## Changes in this PR

### `INSTALL.md`
Added `nasm` and `meson` to the `brew install` command in step 3.

### `core-xprojects/Mozjpeg/Mozjpeg/build.sh`
Added `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` to the CMake invocation. Required for CMake 3.27+ compatibility.

### `core-xprojects/ffmpeg/ffmpeg/build.sh`
Updated `FF_VERSION` from `"7.1"` to `"7.1.1"` to match the actual bundled ffmpeg source directory in the `telegram-ios` submodule.

## Metal Toolchain Workaround

On Xcode 26, the Metal Toolchain cryptex mount doesn't include Swift compatibility libraries. The linker receives an explicit path to `libswiftAppKit.dylib` inside the Metal Toolchain that doesn't exist. Since the cryptex is read-only, symlinks cannot be added.

**Workaround**: Use an LD wrapper script that intercepts the linker invocation and remaps the Metal Toolchain path to the Xcode default toolchain:

```bash
#!/bin/bash
XCODE_LIB="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/macosx/libswiftAppKit.dylib"
args=()
for arg in "$@"; do
    if [[ "$arg" == /var/run/com.apple.security.cryptexd/mnt/com.apple.MobileAsset.MetalToolchain-*/Metal.xctoolchain/usr/lib/swift-5.0/macosx/libswiftAppKit.dylib ]]; then
        args+=("$XCODE_LIB")
    else
        args+=("$arg")
    fi
done
exec /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang "${args[@]}"
```

Save as `/tmp/ld-wrapper.sh`, `chmod +x`, then build with:
```
LD=/tmp/ld-wrapper.sh LDPLUSPLUS=/tmp/ld-wrapper.sh xcodebuild build ...
```

## Submodule issues (upstream)

These issues cannot be fixed in the main TelegramSwift repo:

- **`tg_owt`** — `src/api/candidate.h:108`: `ABSL_ATTRIBUTE_LIFETIME_BOUND` on `set_type()` parameter causes a clang error on Xcode 26. Fix: remove the attribute from that parameter, or update abseil.

## Test plan
- [x] Clone fresh with `--recurse-submodules` on macOS with Xcode 26
- [x] Run `brew install cmake ninja openssl@1.1 zlib autoconf libtool automake yasm nasm meson pkg-config`
- [x] Run `configure_frameworks.sh` — all 10 frameworks build successfully
- [x] Build app with LD wrapper — binary produced successfully
- [x] Verify Mozjpeg framework builds without CMake policy errors
- [x] Verify ffmpeg framework builds without version mismatch errors