### PR TITLE
Fix adjacent blockquotes merging into one

### DIFF
--- a/packages/InputView/Sources/InputView/ChatTextInputAttribute.swift
+++ b/packages/InputView/Sources/InputView/ChatTextInputAttribute.swift
@@ -42,16 +42,6 @@ public final class TextInputTextQuoteAttribute: NSObject {
         self.collapsed = collapsed
         super.init()
     }
-    
-    override public func isEqual(_ object: Any?) -> Bool {
-        guard let other = object as? TextInputTextQuoteAttribute else {
-            return false
-        }
-        
-        let _ = other
-        
-        return self.collapsed == other.collapsed
-    }
 }
 
 public final class TextInputTextCustomEmojiAttribute: NSObject, Codable {
@@ -547,7 +537,7 @@ private func quoteRangesEqual(_ lhs: [(NSRange, TextInputTextQuoteAttribute)], _
         return false
     }
     for i in 0 ..< lhs.count {
-        if lhs[i].0 != rhs[i].0 || !lhs[i].1.isEqual(rhs[i].1) {
+        if lhs[i].0 != rhs[i].0 || lhs[i].1.collapsed != rhs[i].1.collapsed {
             return false
         }
     }


### PR DESCRIPTION
Adjacent blockquotes collapse into a single block when typing or pasting.

**Root cause:** `TextInputTextQuoteAttribute.isEqual` compared only the `collapsed` field, so two non-collapsed quotes were considered equal. `NSAttributedString` merges adjacent attribute runs with equal values — that's what caused the collapse.

**Fix:** Remove the `isEqual` override. `NSObject`'s identity-based equality ensures each quote block stays distinct regardless of its `collapsed` state.

`quoteRangesEqual` is updated to compare `.collapsed` directly instead of calling `isEqual`, which would otherwise always use identity comparison and return false even for structurally identical ranges, causing unnecessary attribute refreshes.