### PR TITLE
Fix code/monospace formatting lost on copy-paste

### DIFF
--- a/Telegram-Mac/InAppLinks.swift
+++ b/Telegram-Mac/InAppLinks.swift
@@ -347,31 +347,24 @@ var globalLinkExecutor:TextViewInteractions {
             }
             
             //modified.removeAttribute(TextInputAttributes.quote, range: modified.range)
-            modified.removeAttribute(TextInputAttributes.code, range: modified.range)
-            modified.removeAttribute(TextInputAttributes.monospace, range: modified.range)
 
             let input = ChatTextInputState(attributedText: modified, selectionRange: 0 ..< modified.length)
-            
+
             if !modified.string.isEmpty {
                 pb.clearContents()
                 let rtf = try? modified.data(from: modified.range, documentAttributes: [NSAttributedString.DocumentAttributeKey.documentType : NSAttributedString.DocumentType.rtf])
-                
-                
-                pb.declareTypes([.rtf, .kInApp], owner: nil)
-
+                pb.declareTypes([.rtf, .kInApp, .string], owner: nil)
                 let encoder = AdaptedPostboxEncoder()
-                let encoded = try? encoder.encode(input)
-                
-                if let data = encoded {
+                if let data = try? encoder.encode(input) {
                     pb.setData(data, forType: .kInApp)
                 }
                 if let rtf = rtf {
                     pb.setData(rtf, forType: .rtf)
-                    pb.setString(modified.string, forType: .string)
-                    return true
                 }
+                pb.setString(modified.string, forType: .string)
+                return true
             }
-            
+
             return false
         }, translate: { text, window in
             let language = Translate.detectLanguage(for: text)


### PR DESCRIPTION
Copying text that contains inline code or monospace runs and pasting it back into Telegram loses the formatting.

**Root cause:** Two `removeAttribute(.code/.monospace)` calls were made on `modified` before `ChatTextInputState` was built from it. Since `NSMutableAttributedString` is a reference type, mutating it afterward affects the already-captured `attributedText` — so the kInApp pasteboard entry ends up with no code/monospace runs.

**Fix:** Remove those two `removeAttribute` calls. `refreshTextInputAttributes` already applies `NSFont.code()` as the `.font` attribute on every code/monospace run, so RTF export naturally produces monospace output with no extra work needed.

Two smaller fixes included:
- Declare all three pasteboard types (`.rtf`, `.kInApp`, `.string`) upfront before setting any values, as required by the `NSPasteboard` API contract
- Always write the plain-string fallback regardless of whether RTF generation succeeded