### PR TITLE
Fix via @bot not shown for inline bot messages in private chats

### DIFF
--- a/Telegram-Mac/ChatRowItem.swift
+++ b/Telegram-Mac/ChatRowItem.swift
@@ -2240,8 +2240,8 @@ class ChatRowItem: TableRowItem {
                 fillName = header == .normal && theme.bubbled
             }
             
-            if fillName {
-                
+            if fillName || message.hasInlineAttribute {
+
                 let canFillAuthorName: Bool = ChatRowItem.canFillAuthorName(message, chatInteraction: chatInteraction, renderType: renderType, isIncoming: isIncoming, hasBubble: hasBubble)
 
                 if isForwardScam || canFillAuthorName {


### PR DESCRIPTION
When you send a message via an inline bot in a private chat, the "via @botname" attribution doesn't appear.

**Root cause:** The author/via-bot header block is gated on `fillName`, which is `false` for outgoing messages in private chats (no author name is needed there). The via @bot line is rendered inside the same block, so it gets skipped.

**Fix:** Also enter the block when `message.hasInlineAttribute` is true, regardless of `fillName`.