### PR TITLE
Render newer bot rich messages as readable fallback

### DIFF
--- a/Telegram-Mac/ChatMessageItem.swift
+++ b/Telegram-Mac/ChatMessageItem.swift
@@ -267,6 +267,9 @@ class ChatMessageItem: ChatRowItem {
     override init(_ initialSize:NSSize, _ chatInteraction:ChatInteraction,_ context: AccountContext, _ entry: ChatHistoryEntry, theme: TelegramPresentationTheme) {
         
          if let message = entry.message {
+            if message.inlinePeer == nil, message.id.namespace == Namespaces.Message.Cloud, message.text.isEmpty, message.media.contains(where: { $0 is TelegramMediaUnsupported }) {
+                chatInteraction.context.account.viewTracker.updateUnsupportedMediaForMessageIds(messageIds: Set([MessageAndThreadId(messageId: message.id, threadId: chatInteraction.chatLocation.threadId)]))
+            }
              
             
             let isIncoming: Bool = message.isIncoming(context.account, entry.renderType == .bubble)
@@ -1030,4 +1033,3 @@ class ChatMessageItem: ChatRowItem {
     }
 
 }
-


### PR DESCRIPTION
## What

Updates the Telegram-iOS submodule to include newer TL compatibility parsing for rich bot messages, and adds a small macOS-side refresh hook for cached unsupported cloud messages.

This makes old cached unsupported rich bot messages request `messages.getRichMessage` again when they appear in chat history, so the fallback text can replace the unsupported placeholder.

## Bug

Bot messages using recent rich formatting can show as:

`This message is not supported in your version of Telegram. Please update to the latest version.`

Repro message used for testing:
https://t.me/ohld_chat/35423

## Build

```bash
./artifacts/build-dev-rich-test-dmg.sh
```

The script builds the macOS app as a separate dev bundle:

- bundle id: `ru.keepcoder.TelegramDevRichTest`
- display name: `Telegram Dev RichTest`
- signing disabled for local testing
- output: `artifacts/Telegram-Dev-RichTest.dmg`

## Test Artifact

Local DMG:
`/Users/ohld/Documents/GitHub/TelegramSwift/artifacts/Telegram-Dev-RichTest.dmg`

SHA256:
`a4a572cbd789f140555753ffc436c686ba7fa7255b720c8e435dfca132af05a3`

## Verification

- `swift build` in `submodules/telegram-ios/submodules/TelegramApi`: passed.
- Full macOS Release arm64 build via `./artifacts/build-dev-rich-test-dmg.sh`: passed.
- Restarted only dev app PID from `artifacts/Telegram Dev RichTest.app`, then opened `https://t.me/ohld_chat/35423`.
- Fresh log checked: `/Users/ohld/Library/Application Support/Telegram Dev RichTest/stable/logs/critlog-2026-6-26_02-28-24.883.txt`

Fresh-log counters:

- `This message is not supported`: 0
- `messageMediaUnsupported`: 0
- `d64c522b`: 0
- `49e91f2a`: 0
- `7600b9d3`, `baf39d8b`, `773f4e66`, `966e2dbf`, `ba7bb15e`: 0

Screenshot automation was attempted locally, but macOS returned a black capture in this environment, so the reliable verification here is build + fresh client logs.

## Related

Submodule PR: https://github.com/overtake/Telegram-iOS/pull/4