### PR TITLE
fix: ignore invalid table row height updates

### DIFF
--- a/packages/TGUIKit/Sources/TableView.swift
+++ b/packages/TGUIKit/Sources/TableView.swift
@@ -2303,6 +2303,9 @@ open class TableView: ScrollView, NSTableViewDelegate,NSTableViewDataSource,Sele
     }
     
     public func noteHeightOfRow(_ row:Int, _ animated:Bool = true) {
+        guard row >= 0 && row < self.count else {
+            return
+        }
         if !animated {
             NSAnimationContext.current.duration = 0
             NSAnimationContext.current.timingFunction = nil


### PR DESCRIPTION
## Summary

- ignore row-height callbacks for rows that are no longer present in the table
- validate both negative and upper-bound row indexes before AppKit animation or array access

## Root cause

During rapid `sendMessageDraft` updates, a live-draft row can be detached before a queued animated height update runs. The callback then reaches `TableView.noteHeightOfRow(-1, true)`.

In Telegram 12.8 build 282011, the faulting register is `x22 = -1`, and the crash PC is the negative-index `brk #1` immediately before `self.list[row]`. The containing function resolves through these Objective-C selectors:

- `currentContext`
- `setDuration:`
- `setTimingFunction:`
- `noteHeightOfRowsWithIndexesChanged:`

That sequence uniquely matches `TableView.noteHeightOfRow(_:_:)`.

The same four-frame signature appears in #1419: the three caller offsets move by `+0x170` in build 282011, while the in-function trap moves by `+0x208`. That report is another instance of this bounds trap rather than `RadialProgressContainerView.init(frame:)`.

Centralizing the guard here also covers direct callers that do not go through `TableRowItem.noteHeightOfRow()`, which already rejects an index of `-1`.

Fixes #1375.
Addresses #1419.

## Validation

- `git diff --check`
- `xcrun swiftc -parse packages/TGUIKit/Sources/TableView.swift`

The standalone TGUIKit build requires the repository's unpopulated `telegram-ios/SSignalKit` submodule, so a full package build was not available in this checkout.
