### PR TITLE
Add Power Saving settings to settings search

### DIFF
--- a/Telegram-Mac/LiteModeController.swift
+++ b/Telegram-Mac/LiteModeController.swift
@@ -12,7 +12,7 @@ import SwiftSignalKit
 import InAppSettings
 import Localization
 
-private extension LiteModeKey {
+extension LiteModeKey {
     var title: String {
         return _NSLocalizedString("LiteMode.Key.\(self.rawValue).Title")
     }

--- a/Telegram-Mac/SettingsSearchableItems.swift
+++ b/Telegram-Mac/SettingsSearchableItems.swift
@@ -29,6 +29,7 @@ enum SettingsSearchableItemIcon {
     case passport
     case support
     case faq
+    case powerSaving
 }
 
 extension SettingsSearchableItemIcon {
@@ -54,6 +55,8 @@ extension SettingsSearchableItemIcon {
             return theme.icons.settingsAskQuestion
         case .faq:
             return theme.icons.settingsFaq
+        case .powerSaving:
+            return theme.icons.settingsGeneral
         default:
             return nil
         }
@@ -79,6 +82,7 @@ enum SettingsSearchableItemId: Hashable {
     case wallet(Int32)
     case support(Int32)
     case faq(Int32)
+    case powerSaving(Int32)
     
     private var namespace: Int32 {
         switch self {
@@ -112,6 +116,8 @@ enum SettingsSearchableItemId: Hashable {
             return 14
         case .faq:
             return 15
+        case .powerSaving:
+            return 16
         }
     }
     
@@ -131,7 +137,8 @@ enum SettingsSearchableItemId: Hashable {
              let .passport(id),
              let .wallet(id),
              let .support(id),
-             let .faq(id):
+             let .faq(id),
+             let .powerSaving(id):
             return id
         }
     }
@@ -174,6 +181,8 @@ enum SettingsSearchableItemId: Hashable {
             self = .support(id)
         case 15:
             self = .faq(id)
+        case 16:
+            self = .powerSaving(id)
         default:
             return nil
         }
@@ -629,6 +638,33 @@ private func languageSearchableItems(context: AccountContext, localizations: [Lo
     return items
 }
 
+private func powerSavingSearchableItems(context: AccountContext) -> [SettingsSearchableItem] {
+    let icon: SettingsSearchableItemIcon = .powerSaving
+
+    let presentLiteMode: (AccountContext, (SettingsSearchableItemPresentation, ViewController?) -> Void) -> Void = { context, present in
+        present(.push, LiteModeController(context: context))
+    }
+
+    var items: [SettingsSearchableItem] = []
+    items.append(SettingsSearchableItem(id: .powerSaving(0), title: strings().generalSettingsLiteMode, alternate: [strings().liteModeTitle, strings().liteModeInfo], icon: icon, breadcrumbs: [strings().accountSettingsGeneral], present: { context, _, present in
+        presentLiteMode(context, present)
+    }))
+
+    var index: Int32 = 1
+    for key in LiteMode.allKeys {
+        var alternate: [String] = []
+        if let info = key.info {
+            alternate.append(info)
+        }
+        items.append(SettingsSearchableItem(id: .powerSaving(index), title: key.title, alternate: alternate, icon: icon, breadcrumbs: [strings().accountSettingsGeneral, strings().generalSettingsLiteMode], present: { context, _, present in
+            presentLiteMode(context, present)
+        }))
+        index += 1
+    }
+
+    return items
+}
+
 func settingsSearchableItems(context: AccountContext, archivedStickerPacks: Signal<[ArchivedStickerPackItem]?, NoError>, privacySettings: Signal<AccountPrivacySettings?, NoError>) -> Signal<[SettingsSearchableItem], NoError> {
     
     let canAddAccount = activeAccountsAndPeers(context: context)
@@ -730,6 +766,9 @@ func settingsSearchableItems(context: AccountContext, archivedStickerPacks: Sign
             
             let appearanceItems = appearanceSearchableItems(context: context)
             allItems.append(contentsOf: appearanceItems)
+            
+            let powerSavingItems = powerSavingSearchableItems(context: context)
+            allItems.append(contentsOf: powerSavingItems)
             
             let languageItems = languageSearchableItems(context: context, localizations: localizations)
             allItems.append(contentsOf: languageItems)


### PR DESCRIPTION
### Problem

The Power Saving (lite mode) screen is not in the settings search index. `settingsSearchableItems` builds the index from explicit per-section lists (profile, stickers, notifications, privacy, data, proxy, appearance, language), and no list was ever added for lite mode when it shipped.

The practical effect: searching Settings for `emoji`, `animation`, `sticker animation` or `power` returns nothing for these toggles. Since the screen is named after a motivation (saving battery) rather than what it controls (looping emoji, stickers, GIFs, videos, blur, menu animations), a user who wants to stop animated emoji from looping has no path to it except already knowing it lives under General.

This is easy to hit in practice — the toggle people usually want is **Emoji Animations**, and search is the natural way to look for it.

### Change

Adds `powerSavingSearchableItems`, indexing:

- the screen itself, under its existing title `GeneralSettings.LiteMode`, breadcrumb `General`
- every toggle in `LiteMode.allKeys`, using each key's existing `.title`, breadcrumbs `General › Power Saving Mode`

Each key's `.info` text is passed as `alternate`, so the descriptions already shown on the rows become searchable too — e.g. "Loop animated emoji in messages, reactions and statuses" makes `loop`, `reactions` and `statuses` find the Emoji Animations toggle.

All items push `LiteModeController`. There is no item-tag/focus mechanism on that controller, so sub-items open the screen rather than scrolling to a specific row, matching how the language and sticker items behave.

Supporting changes:

- new `.powerSaving` case in `SettingsSearchableItemIcon` (reuses `theme.icons.settingsGeneral`) and in `SettingsSearchableItemId` (namespace 16, appended so existing persisted recent-search indices keep their meaning)
- `extension LiteModeKey` in `LiteModeController.swift` is no longer `private`, so the search items reuse the exact strings the rows render

**No new localized strings** — everything reuses keys that already exist.

### Notes

Synonyms are deliberately not added. Words like "battery" would need new `SettingsSearch.Synonyms.*` entries, which go through the translations platform; happy to add them in a follow-up if you'd like.

Verified by inspection and `swiftc -parse`; I wasn't set up to run a full Xcode build locally, so please give it a compile before merging.